### PR TITLE
docs: add 'Submit your dApp to the store' page (explore.dig.net listing flow)

### DIFF
--- a/docs/audiences/app-developers.md
+++ b/docs/audiences/app-developers.md
@@ -96,6 +96,14 @@ Wire `dig-network/deploy-action` so every push publishes a new capsule — with 
 
 → [Deploy from GitHub Actions](../digstore/cli/deploy-from-github-actions.md)
 
+## List your dApp in the store
+
+Once your dApp is live, submit it to the [DIG Network dApp store](https://explore.dig.net) — connect
+your wallet at [hub.dig.net/submit](https://hub.dig.net/submit), fill in one form, and an admin
+review publishes it for you.
+
+→ [Submit your dApp to the store](../build-a-dapp/submit-to-the-store.md)
+
 ## Add a `*.on.dig.net` web address (optional)
 
 Your store is reachable by its [URN](../concepts.md#urn) / [`chia://`](../browser/chia-protocol.md) address the moment it confirms — no extra cost. A human-friendly `<name>.on.dig.net` handle is an **optional, paid** registration in DIGHUb on top of that.

--- a/docs/build-a-dapp/submit-to-the-store.md
+++ b/docs/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/docs/journeys/hub-user.md
+++ b/docs/journeys/hub-user.md
@@ -49,6 +49,14 @@ Every store has a public **tip page** (`https://hub.dig.net/tip/store/<your stor
 
 → [Get tipped for your store](../build-a-dapp/tip-your-store.md)
 
+## How do I list my dApp in the DIG Network dApp store?
+
+Connect your wallet at [hub.dig.net/submit](https://hub.dig.net/submit), fill in your dApp's details
+and artwork, and submit for review. An admin reviews it, and once approved DIGHUb publishes it to
+[explore.dig.net](https://explore.dig.net) automatically — no repository or pull request on your end.
+
+→ [Submit your dApp to the store](../build-a-dapp/submit-to-the-store.md)
+
 ## How do I let CI publish for me?
 
 Issue a **deploy key** (a revocable key that can publish but never touch ownership) in your store's **Automation** tab, then wire it into CI — or use the GitHub deploy Action for push-to-publish with free PR previews.

--- a/i18n/de/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/i18n/es/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/i18n/hi/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/hi/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/i18n/id/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/id/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/i18n/ko/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/i18n/ru/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/i18n/tr/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/tr/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/i18n/zh-TW/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
+++ b/i18n/zh-TW/docusaurus-plugin-content-docs/current/build-a-dapp/submit-to-the-store.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 1.9
+title: Submit your dApp to the store
+description: "List your dApp on the DIG Network dApp store (explore.dig.net): connect your wallet on DIGHUb, fill in the submission form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — no repository, no pull request, no waiting on infrastructure."
+keywords:
+  - submit a dapp
+  - list on explore.dig.net
+  - DIG Network dApp store
+  - dApp store submission
+  - DIGHUb submit
+tags:
+  - dighub
+  - store
+  - dapp-store
+---
+
+# Submit your dApp to the store
+
+> **List your dApp on the DIG Network dApp store** — [explore.dig.net](https://explore.dig.net), the curated
+> directory of dApps built on Chia. Connect your wallet on [DIGHUb](../concepts.md#dighub), fill in one
+> form, and an admin reviews it. Once approved, DIGHUb opens the listing for you automatically — you
+> never touch a repository or a pull request.
+
+## The mental model
+
+The DIG Network dApp store is **curated**: every listing is reviewed before it goes live. Submitting
+is a single wallet-gated form on DIGHUb at **[hub.dig.net/submit](https://hub.dig.net/submit)** — your
+Chia wallet **is** your identity here, so there's no separate account or password. Fill in your dApp's
+details and artwork, submit for review, and track its status on the same page. An admin reviews the
+submission; once approved, DIGHUb publishes it to explore.dig.net for you.
+
+## Before you start
+
+Gather these first so the form goes quickly:
+
+- **The basics** — your dApp's name, a one-line tagline, a longer description, its category, a
+  handful of search tags, its live URL, and your (or your team's) name.
+- **Artwork** — a square app icon and a social-share image are **required to list**; a wide hero
+  image and at least two desktop screenshots are needed if you want your dApp considered for the
+  **featured** shelf. See [Artwork requirements](#artwork-requirements) below for exact sizes.
+- **Optional extras** — a public source repository, your dApp's own version, its license, and links
+  to docs, Discord, X, YouTube, or a blog.
+
+## Submit your dApp
+
+1. **Connect your wallet** at [hub.dig.net/submit](https://hub.dig.net/submit). If you're signed
+   out, DIGHUb asks you to connect before showing the form — the wallet you connect becomes the
+   submission's owner, so you (and only you) can see its status afterward.
+2. **Fill in the form**, organized into four sections:
+   - **About your dApp** — slug (the URL-safe name your listing uses, e.g. `my-dapp`), name, tagline,
+     and description.
+   - **Details** — category, tags, your live website URL, author name (and an optional author URL),
+     status (Live, Beta, or Draft), an accent color that themes your listing, and an optional version
+     string.
+   - **Links** *(optional)* — a public source repository, a license identifier, and any of docs,
+     Discord, X, YouTube, or a blog.
+   - **Artwork** — upload your PNGs; see [Artwork requirements](#artwork-requirements).
+3. **Submit for review.** DIGHUb uploads your artwork and hands the submission to an admin queue.
+   Your submission then appears under **Your submissions** on the same page, with a live status:
+
+   | Status | Meaning |
+   |---|---|
+   | Uploading | Your artwork is still being uploaded. |
+   | In review | Everything uploaded; waiting on an admin. |
+   | Approved | An admin approved it — the listing PR is open. |
+   | Published | The listing is live on explore.dig.net. |
+   | Rejected | An admin declined it (with a reason you can read). |
+   | Needs a retry | Approved, but publishing hit a snag — DIGHUb will retry automatically. |
+
+4. **An admin reviews it.** Reviews check the same things every explore.dig.net listing must satisfy —
+   working product, accurate metadata, and artwork that meets the size requirements below. If a
+   submission is declined, you'll see the reason and can submit again.
+5. **Once approved, it's published — no extra step from you.** DIGHUb opens the listing on
+   explore.dig.net on your behalf and, once it passes the store's automated checks, it goes live at
+   `explore.dig.net/app/<your-slug>`. Your submission's status updates to **Published** when it does.
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| Slug | yes | Lowercase letters, numbers, and hyphens, 3–40 characters (e.g. `my-dapp`) — this becomes your listing's URL. |
+| Name | yes | 1–40 characters, as you want it branded. |
+| Tagline | yes | 10–120 characters, plain text — your one-line pitch. |
+| Description | yes | 80–5,000 characters; basic markdown (paragraphs, headings, lists, bold/italic/code/links) is supported. |
+| Category | yes | One primary category: Payments, DeFi, NFTs, Gaming, Social, Storage, Identity, Infrastructure, Tools, or Other. |
+| Tags | yes | 1–8 short keywords, comma-separated. |
+| Website | yes | Your live dApp — must start with `https://`. |
+| Author / team name | yes | 1–60 characters. |
+| Author URL | optional | Must be `https://` if set. |
+| Status | yes | Live, Beta, or Draft. A Draft listing shows a Draft badge and can't be featured. |
+| Accent color | yes | A `#RRGGBB` color that themes your listing's card and detail page. |
+| Source repository | optional | A public `https://github.com/...` link. Open-source dApps are preferred. |
+| Version | optional | Your dApp's own release version. |
+| License | optional | An SPDX identifier (e.g. `MIT`, `GPL-2.0`). |
+| Docs / Discord / X / YouTube / Blog | optional | Any that apply, each `https://`. |
+
+Every listing you submit starts **not featured** — featuring is a curation decision the store team
+makes after your dApp is live, not something you set yourself.
+
+## Artwork requirements
+
+Every image is a **PNG at the exact pixel size** shown — the store validates this automatically, so
+double-check your export before uploading.
+
+| Image | Exact size | Max size | Required |
+|---|---|---|---|
+| App icon | 512 × 512 | 512 KiB | **to list** |
+| Social share image | 1200 × 630 | 1 MiB | **to list** |
+| App icon (large) | 1024 × 1024 | 1 MiB | optional |
+| Hero image | 1600 × 900 | 2 MiB | **to be featured** |
+| Tile image | 800 × 450 | 1 MiB | optional |
+| Desktop screenshots | 1280 × 800 | 2 MiB each | up to 8; **2+ needed to be featured** |
+| Mobile screenshots | 1080 × 1920 | 2 MiB each | up to 8 |
+
+Screenshots should be real captures of your running dApp, numbered in the order you upload them.
+
+## What happens after you submit
+
+Once your submission is **Published**, it's a normal explore.dig.net listing: discoverable in the
+store's search and category filters, with its own detail page and social-share card. Updating a
+published listing's metadata or artwork later isn't yet available from the submission form — for now,
+each submission creates one listing.
+
+## Stuck?
+
+- [FAQ](../support/faq.md) — quick answers about DIGHUb.
+- [Get help](../support/get-help.md) — the community and how to file a good report.
+
+---
+
+## Go deeper
+
+- **Publish the dApp itself first** → [For app developers](../audiences/app-developers.md) — ship
+  your site or app before you list it in the store.
+- **The full picture for using DIGHUb** → [How do I… use DIGHUb?](../journeys/hub-user.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-dig-net",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -53,6 +53,7 @@ const sidebars: SidebarsConfig = {
             'digstore/cli/onchain-anchoring',
             'digstore/cli/sharing',
             'build-a-dapp/tip-your-store',
+            'build-a-dapp/submit-to-the-store',
             'digstore/cli/deploy-from-github-actions',
             'automation/deploy-keys',
             'automation/webhooks',

--- a/static/knowledge-graph.json
+++ b/static/knowledge-graph.json
@@ -311,6 +311,17 @@
       ]
     },
     {
+      "id": "/docs/build-a-dapp/submit-to-the-store",
+      "type": "doc",
+      "title": "Submit your dApp to the store",
+      "url": "https://docs.dig.net/docs/build-a-dapp/submit-to-the-store",
+      "tags": [
+        "dighub",
+        "store",
+        "dapp-store"
+      ]
+    },
+    {
       "id": "/docs/build-a-dapp/tip-your-store",
       "type": "doc",
       "title": "Get tipped for your store",
@@ -1530,6 +1541,16 @@
     {
       "from": "/docs/build-a-dapp/scaffold",
       "to": "concept:dig-payment",
+      "type": "part-of"
+    },
+    {
+      "from": "/docs/build-a-dapp/submit-to-the-store",
+      "to": "concept:dighub",
+      "type": "part-of"
+    },
+    {
+      "from": "/docs/build-a-dapp/submit-to-the-store",
+      "to": "concept:store",
       "type": "part-of"
     },
     {

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -43,6 +43,7 @@ The docs are organized in two top-level sections: **Using DIG** (one track per a
 - [Build a dapp on Chia](https://docs.dig.net/docs/build-a-dapp/tutorial): the end-to-end thread — scaffold a React app (digstore new / npm create dig-app), develop free (digstore dev), wire the in-page wallet (window.chia + WalletConnect fallback via @dignetwork/dig-sdk), build and sign a spend (chip35 wasm via the SDK /spend subpath), deploy on-chain (the uniform capsule price in $DIG), and add a custom domain.
 - [Scaffold an app (create-dig-app)](https://docs.dig.net/docs/build-a-dapp/scaffold): npm create dig-app — the JS front door; scaffolds a runnable starter (app + dig.toml + the DIG SDK on wallet templates) from five templates (static, vite-react, next-static, nft-drop, dapp-window-chia). Free to scaffold/build/preview; the uniform capsule price in $DIG only at publish. The npm companion to the Rust CLI's digstore new.
 - [Example gallery](https://docs.dig.net/docs/build-a-dapp/example-gallery): example projects mapped to scaffold templates — static, vite-react, nft-drop, next-static, dapp-window-chia (example repo links are placeholders during pre-release).
+- [Submit your dApp to the store](https://docs.dig.net/docs/build-a-dapp/submit-to-the-store): list a dApp on the DIG Network dApp store (explore.dig.net) — connect a wallet at hub.dig.net/submit, fill in metadata + artwork, submit for review; an admin approval publishes the listing automatically, no repository or pull request needed from the submitter.
 
 ## DigStore CLI (integrating developers)
 

--- a/static/openrpc-node.json
+++ b/static/openrpc-node.json
@@ -2,7 +2,7 @@
   "openrpc": "1.2.6",
   "info": {
     "title": "dig RPC — node profile (local dig-node / in-process DIG Browser)",
-    "version": "1.0.0",
+    "version": "0.2.0",
     "description": "The NODE PROFILE: a distinct, smaller surface than the network profile. Of the byte methods it implements ONLY dig.getContent (local-first, else proxy); everything else proxies upstream or returns -32601. It ADDS node-only methods the security model depends on — chiefly dig.getAnchoredRoot (the CHIP-0035 on-chain head, the trusted root for mandatory root-pinning), dig.stage, and cache.*. Gate on dig.methods rather than assuming one uniform surface. See https://docs.dig.net/docs/protocol/dig-rpc#node-profile.",
     "license": {
       "name": "GPL-2.0",

--- a/static/openrpc.json
+++ b/static/openrpc.json
@@ -2,7 +2,7 @@
   "openrpc": "1.2.6",
   "info": {
     "title": "dig RPC — DIG Network Content Interface (network profile)",
-    "version": "1.0.0",
+    "version": "0.2.0",
     "description": "The network-wide read interface for DIG content over JSON-RPC 2.0 — the NETWORK PROFILE served by the canonical node at rpc.dig.net. Blind by construction (the node holds no URN and no key), verifiable without trust (merkle inclusion proofs against the chain-anchored root), and streamable at any size. There is no `decoy` field on the wire and no CDN. See https://docs.dig.net/docs/protocol/dig-rpc.",
     "license": {
       "name": "GPL-2.0",


### PR DESCRIPTION
## What

Adds a user-facing, task-oriented docs page — **Submit your dApp to the store** — explaining how a developer lists their dApp on the DIG Network dApp store ([explore.dig.net](https://explore.dig.net)):

1. Connect a wallet at [hub.dig.net/submit](https://hub.dig.net/submit) (the wallet is the submitter identity — no separate account).
2. Fill in the submission form: metadata (slug, name, tagline, description, category, tags, URL, author, status, accent color, optional repo/version/license/links) + artwork.
3. Submit for review and track status (Uploading → In review → Approved → Published, or Rejected / Needs a retry).
4. An admin reviews; once approved, DIGHUb opens the listing on explore.dig.net automatically — the submitter never touches a repository or a pull request.

The page includes a full **field reference** and the exact **PNG artwork sizes** (icon-512 512×512 + og 1200×630 required to list; hero 1600×900 + 2 desktop screenshots to be featured; screenshot sizes and caps), all sourced from the shipped submission contract so the doc matches what the form enforces.

### IA + cross-links
- Slots into the **App developers** sidebar after "Get tipped for your store" (`build-a-dapp/submit-to-the-store`).
- Cross-linked from the app-developers landing ("List your dApp in the store") and the DIGHUb how-to journey ("How do I list my dApp in the DIG Network dApp store?").

### Saturation-search
Searched the docs tree for anything the submission flow makes stale — there was **no prior mention** of explore.dig.net or a dApp store anywhere in docs, so this is net-new content with no contradictions to fix.

### Machine surfaces / i18n
- `static/llms.txt` updated with the new page under "Build a dapp".
- Materialized the page into **all 14 locales** (English source; matches the repo's existing untranslated-materialization pattern) so links resolve under `onBrokenLinks: "throw"`.
- Derived `static/knowledge-graph.json` regenerated (new node + edges). `static/openrpc*.json` regenerate to carry the bumped site version (they read `package.json` `version`).

## Version bump
**Minor: 0.1.0 → 0.2.0** — a new documentation page is a backwards-compatible new capability (`docs:` adding a new section).

## How verified
- [x] `npm run typecheck` — clean
- [x] `npm run build` — green across all 14 locales (`onBrokenLinks`/`onBrokenAnchors: "throw"` — no broken links/anchors)
- [x] `npm run test:unit` — virtual-screen-reader trace passes
- [x] `npm run test:a11y` — all 22 Playwright a11y/SEO tests pass (axe WCAG 2.2 AA, ARIA snapshots, keyboard nav, mobile viewport)
- [ ] CI green on this PR (will monitor)